### PR TITLE
Add tracing for akka-http without passing the span

### DIFF
--- a/akka-http/src/test/scala/io/opencensus/scala/akka/http/ServiceRequirementsSpec.scala
+++ b/akka-http/src/test/scala/io/opencensus/scala/akka/http/ServiceRequirementsSpec.scala
@@ -1,0 +1,157 @@
+package io.opencensus.scala.akka.http
+
+import akka.http.scaladsl.model.{HttpHeader, HttpRequest, StatusCodes}
+import akka.http.scaladsl.server.{Directives, Route, StandardRoute}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import io.opencensus.scala.Tracing
+import io.opencensus.scala.akka.http.AkkaMockPropagation._
+import io.opencensus.scala.http.ServiceData
+import io.opencensus.scala.http.propagation.Propagation
+import io.opencensus.scala.http.testSuite.MockTracing
+import io.opencensus.trace.{AttributeValue, Status}
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+
+trait ServiceRequirementsSpec
+    extends FlatSpec
+    with Matchers
+    with ScalatestRouteTest
+    with OptionValues {
+
+  type RouteResult = () => StandardRoute
+
+  def tracedService(
+      routeFromTracingDirectiveAndResult: TracingDirective => RouteResult => Route,
+      serviceData: Option[ServiceData]
+  ): Unit = {
+
+    val path = "/my/fancy/path"
+
+    it should "start a span with the path of the request" in {
+      val (directive, mockTracing) = directiveWithMock()
+
+      Get(path) ~> routeFromTracingDirectiveAndResult(directive)(
+        () => Directives.complete("")
+      ) ~> check {
+        mockTracing.startedSpans.map(_.name) should contain(path)
+      }
+    }
+
+    it should "start a span without parent context when no span context was propagated" in {
+      val (directive, mockTracing) = directiveWithMock()
+
+      Get(requestPathWithoutParent) ~> routeFromTracingDirectiveAndResult(
+        directive
+      )(() => Directives.complete("")) ~> check {
+        val parentSpanContext =
+          mockTracing.startedSpans.headOption.value.parentContext
+        parentSpanContext shouldBe empty
+      }
+    }
+
+    it should "start a span with the propagated context as parent when a span context was propagated" in {
+      val (directive, mockTracing) = directiveWithMock()
+
+      Get(path) ~> routeFromTracingDirectiveAndResult(directive)(
+        () => Directives.complete("")
+      ) ~> check {
+        val parentSpanContext =
+          mockTracing.startedSpans.headOption.value.parentContext.value
+
+        parentSpanContext.getTraceId.toLowerBase16 shouldBe fakeTraceId
+        parentSpanContext.getSpanId.toLowerBase16 shouldBe fakeSpanId
+      }
+
+    }
+
+    it should "end a span with status OK when the route is successfull" in {
+      val (directive, mockTracing) = directiveWithMock()
+
+      Get(path) ~> routeFromTracingDirectiveAndResult(directive)(
+        () => Directives.complete("")
+      ) ~> check {
+        responseEntity.discardBytes() // drain entity so the span gets closed
+        mockTracing.endedSpans.map(_._2.get) should contain(Status.OK)
+      }
+    }
+
+    it should "end a span with status UNKNOWN when the route completes with an errornous status code" in {
+      val (directive, mockTracing) = directiveWithMock()
+
+      Get(path) ~> routeFromTracingDirectiveAndResult(directive)(
+        () => Directives.complete(StatusCodes.InternalServerError)
+      ) ~> check {
+        responseEntity.discardBytes() // drain entity so the span gets closed
+        mockTracing.endedSpans.map(_._2.get) should contain(Status.UNKNOWN)
+      }
+    }
+
+    it should "end a span with status INTERNAL when the route fails" in {
+      val (directive, mockTracing) = directiveWithMock()
+
+      Get(path) ~> routeFromTracingDirectiveAndResult(directive)(
+        () => throw new Exception("test exception")
+      ) ~> check {
+        mockTracing.endedSpans.map(_._2.get) should contain(Status.INTERNAL)
+      }
+    }
+
+    it should "set the http attributes" in {
+      import AttributeValue._
+      val (directive, mockTracing) = directiveWithMock()
+
+      Get(path) ~> routeFromTracingDirectiveAndResult(directive)(
+        () => Directives.complete("")
+      ) ~> check {
+        val startedSpan = mockTracing.startedSpans.headOption.value
+        val attributes  = startedSpan.attributes
+
+        attributes.get("http.host").value shouldBe stringAttributeValue(
+          "example.com"
+        )
+        attributes.get("http.path").value shouldBe stringAttributeValue(
+          "/my/fancy/path"
+        )
+        attributes.get("http.method").value shouldBe stringAttributeValue("GET")
+        attributes.get("http.status_code").value shouldBe longAttributeValue(
+          200L
+        )
+      }
+    }
+
+    it should "set the service attributes when given" in {
+      import AttributeValue._
+      val (directive, mockTracing) = directiveWithMock()
+
+      Get(path) ~> routeFromTracingDirectiveAndResult(directive)(
+        () => Directives.complete("")
+      ) ~> check {
+        val startedSpan = mockTracing.startedSpans.headOption.value
+        val attributes  = startedSpan.attributes
+
+        serviceData match {
+          case Some(ServiceData(Some(name), Some(version))) =>
+            attributes.get("service.name").value shouldBe stringAttributeValue(
+              name
+            )
+            attributes
+              .get("service.version")
+              .value shouldBe stringAttributeValue(
+              version
+            )
+          case None => succeed
+        }
+      }
+    }
+  }
+
+  def directiveWithMock() = {
+    val mockTracing = new MockTracing
+    val directive = new TracingDirective {
+      override protected def tracing: Tracing = mockTracing
+      override protected def propagation: Propagation[HttpHeader, HttpRequest] =
+        AkkaMockPropagation
+    }
+
+    (directive, mockTracing)
+  }
+}

--- a/akka-http/src/test/scala/io/opencensus/scala/akka/http/TracingDirectiveSpec.scala
+++ b/akka-http/src/test/scala/io/opencensus/scala/akka/http/TracingDirectiveSpec.scala
@@ -1,139 +1,43 @@
 package io.opencensus.scala.akka.http
 
-import akka.http.scaladsl.model.{HttpHeader, HttpRequest, StatusCodes}
 import akka.http.scaladsl.server.Directives
-import akka.http.scaladsl.testkit.ScalatestRouteTest
-import io.opencensus.scala.Tracing
-import io.opencensus.scala.akka.http.AkkaMockPropagation._
 import io.opencensus.scala.http.ServiceData
-import io.opencensus.scala.http.propagation.Propagation
-import io.opencensus.scala.http.testSuite.MockTracing
-import io.opencensus.trace.{AttributeValue, Status}
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
 
-class TracingDirectiveSpec
-    extends FlatSpec
-    with Matchers
-    with ScalatestRouteTest
-    with OptionValues {
+class TracingDirectiveSpec extends ServiceRequirementsSpec {
 
-  behavior of "traceRequest"
+  "traceRequest" should behave like tracedService(
+    routeFromTracingDirectiveAndResult =
+      directive => completeWith => directive.traceRequest(_ => completeWith()),
+    serviceData = None
+  )
 
-  val path = "/my/fancy/path"
-
-  it should "start a span with the path of the request" in {
-    val (directive, mockTracing) = directiveWithMock()
-
-    Get(path) ~> directive.traceRequest(_ => Directives.complete("")) ~> check {
-      mockTracing.startedSpans.map(_.name) should contain(path)
-    }
-  }
-
-  it should "start a span without parent context when no span context was propagated" in {
-    val (directive, mockTracing) = directiveWithMock()
-
-    Get(requestPathWithoutParent) ~> directive.traceRequest(
-      _ => Directives.complete("")
-    ) ~> check {
-      val parentSpanContext =
-        mockTracing.startedSpans.headOption.value.parentContext
-      parentSpanContext shouldBe empty
-    }
-  }
-
-  it should "start a span with the propagated context as parent when a span context was propagated" in {
-    val (directive, mockTracing) = directiveWithMock()
-
-    Get(path) ~> directive.traceRequest(_ => Directives.complete("")) ~> check {
-      val parentSpanContext =
-        mockTracing.startedSpans.headOption.value.parentContext.value
-
-      parentSpanContext.getTraceId.toLowerBase16 shouldBe fakeTraceId
-      parentSpanContext.getSpanId.toLowerBase16 shouldBe fakeSpanId
-    }
-
-  }
-
-  it should "end a span with status OK when the route is successfull" in {
-    val (directive, mockTracing) = directiveWithMock()
-
-    Get(path) ~> directive.traceRequest(_ => Directives.complete("")) ~> check {
-      responseEntity.discardBytes() // drain entity so the span gets closed
-      mockTracing.endedSpans.map(_._2.get) should contain(Status.OK)
-    }
-  }
-
-  it should "end a span with status UNKNOWN when the route completes with an errornous status code" in {
-    val (directive, mockTracing) = directiveWithMock()
-
+  it should "pass the span to the inner route" in {
+    val path           = "/my/fancy/path"
+    val (directive, _) = directiveWithMock()
     Get(path) ~> directive.traceRequest(
-      _ => Directives.complete(StatusCodes.InternalServerError)
+      span => Directives.complete(span.getContext.toString)
     ) ~> check {
-      responseEntity.discardBytes() // drain entity so the span gets closed
-      mockTracing.endedSpans.map(_._2.get) should contain(Status.UNKNOWN)
+      entityAs[String] should include("SpanContext")
     }
   }
 
-  it should "end a span with status INTERNAL when the route fails" in {
-    val (directive, mockTracing) = directiveWithMock()
+  "traceRequestNoSpan" should behave like tracedService(
+    routeFromTracingDirectiveAndResult =
+      directive => completeWith => directive.traceRequestNoSpan(completeWith()),
+    serviceData = None
+  )
 
-    Get(path) ~> directive.traceRequest(
-      _ => throw new Exception("test exception")
-    ) ~> check {
-      mockTracing.endedSpans.map(_._2.get) should contain(Status.INTERNAL)
-    }
-  }
-
-  it should "set the http attributes" in {
-    import AttributeValue._
-    val (directive, mockTracing) = directiveWithMock()
-
-    Get(path) ~> directive.traceRequest(_ => Directives.complete("")) ~> check {
-      val startedSpan = mockTracing.startedSpans.headOption.value
-      val attributes  = startedSpan.attributes
-
-      attributes.get("http.host").value shouldBe stringAttributeValue(
-        "example.com"
-      )
-      attributes.get("http.path").value shouldBe stringAttributeValue(
-        "/my/fancy/path"
-      )
-      attributes.get("http.method").value shouldBe stringAttributeValue("GET")
-      attributes.get("http.status_code").value shouldBe longAttributeValue(200L)
-    }
-  }
-
-  behavior of "traceRequestForService"
-
-  it should "set the service attributes" in {
-    import AttributeValue._
-    val (directive, mockTracing) = directiveWithMock()
-
-    val tracingDirective =
-      directive.traceRequestForService(ServiceData("myname", "myversion"))
-
-    Get(path) ~> tracingDirective(_ => Directives.complete("")) ~> check {
-      val startedSpan = mockTracing.startedSpans.headOption.value
-      val attributes  = startedSpan.attributes
-
-      attributes.get("service.name").value shouldBe stringAttributeValue(
-        "myname"
-      )
-
-      attributes.get("service.version").value shouldBe stringAttributeValue(
-        "myversion"
-      )
-    }
-  }
-
-  def directiveWithMock() = {
-    val mockTracing = new MockTracing
-    val directive = new TracingDirective {
-      override protected def tracing: Tracing = mockTracing
-      override protected def propagation: Propagation[HttpHeader, HttpRequest] =
-        AkkaMockPropagation
-    }
-
-    (directive, mockTracing)
-  }
+  val data = ServiceData("Name", "X.X.Y")
+  "traceRequestForService" should behave like tracedService(
+    routeFromTracingDirectiveAndResult = directive =>
+      completeWith =>
+        directive.traceRequestForService(data)(_ => completeWith()),
+    serviceData = Some(data)
+  )
+  "traceRequestForServiceNoSpan" should behave like tracedService(
+    routeFromTracingDirectiveAndResult = directive =>
+      completeWith =>
+        directive.traceRequestForServiceNoSpan(data)(completeWith()),
+    serviceData = Some(data)
+  )
 }


### PR DESCRIPTION
This lets us now also run all tests for each of the api methods.