### PR TITLE
Allow using external stackdriver credentials

### DIFF
--- a/core/src/main/scala/io/opencensus/scala/trace/exporters/Stackdriver.scala
+++ b/core/src/main/scala/io/opencensus/scala/trace/exporters/Stackdriver.scala
@@ -26,19 +26,18 @@ private[scala] object Stackdriver extends LazyLogging {
       .builder()
       .setProjectId(projectId)
 
-    credentialsFile.foreach { path =>
-      val credentials = GoogleCredentials
-        .fromStream(this.getClass.getResourceAsStream(path))
+    val googleCredentials =
+      credentialsFile
+        .fold(GoogleCredentials.getApplicationDefault)(path =>
+          GoogleCredentials.fromStream(this.getClass.getResourceAsStream(path))
+        )
         .createScoped(
           Set(
             "https://www.googleapis.com/auth/cloud-platform",
             "https://www.googleapis.com/auth/trace.append"
           ).asJava
         )
-
-      stackdriverConfig.setCredentials(credentials)
-    }
-
+    stackdriverConfig.setCredentials(googleCredentials)
     stackdriverConfig.build()
   }
 


### PR DESCRIPTION
Currently, the only way to provide credentials for Stackdriver
exporter is by file inside application's jar resources. This
means credentials file needs to baked into application jar.

This solution uses credentials pointed by `GOOGLE_APPLICATION_CREDENTIALS` env
 when `credentialsFile` if not specified in `application.conf`.

Related: #112 